### PR TITLE
Allow the vmware-esx builder, add defaults for resource pool and folder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ output step to create OVF files.
 Compatibility
 -------------
 
-So far this has been tested with Virtualbox 5.1.6, VSphere running ESXI 5.5, and packer 0.10.1. I see no
+So far this has been tested with Virtualbox 5.1.6, VSphere running ESXI 5.5 & 6.5, and packer 0.10.1 & 1.0.0. I see no
 reason why other combinations won't work as well.
 
 Installing

--- a/README.md
+++ b/README.md
@@ -16,41 +16,41 @@ Installing
 Download your platform-specific binary from the [latest releases page](https://github.com/andrewstucki/packer-post-processor-vsphere-template/releases/latest). Either
 put your binary somewhere accessible on your path or reference the absolute path to the binary in
 your `$HOME/.packerconfig` file, like this:
-
-    {
-      "post-processors": {
-        "vsphere-template": "/path/to/packer-post-processor-vsphere-template"
-      }
-    }
+```
+{
+  "post-processors": {
+    "vsphere-template": "/path/to/packer-post-processor-vsphere-template"
+  }
+}
+```
 
 Use the post-processor as follows in your packer manifest:
-
-    "post-processors": [
-      {
-        "type":            "vsphere-template",
-        "host":            "{{user `vsphere_host`}}",
-        "username":        "{{user `vsphere_username`}}",
-        "password":        "{{user `vsphere_password`}}",
-        "datacenter":      "{{user `vsphere_datacenter`}}",
-        "resource_pool":   "{{user `vsphere_resource_pool`}}",
-        "folder":          "{{user `vsphere_folder`}}",
-        "datastore":       "{{user `vsphere_datastore`}}"
-      }
-    ]
+```
+"post-processors": [
+  {
+    "type":            "vsphere-template",
+    "host":            "{{user `vsphere_host`}}",
+    "username":        "{{user `vsphere_username`}}",
+    "password":        "{{user `vsphere_password`}}",
+    "datacenter":      "{{user `vsphere_datacenter`}}",
+    "datastore":       "{{user `vsphere_datastore`}}"
+  }
+]
+```
 
 The following attributes are available:
 
-| Attribute        | Description                                                             | Required/Optional |
-| ---------------- | ----------------------------------------------------------------------- | ----------------- |
-| host             | VCenter host for API calls                                              | required          |
-| username         | Username to use for auth                                                | required          |
-| password         | Password to use for auth                                                | required          |
-| datacenter       | The datacenter where the template will be deployed                      | required          |
-| resource_pool    | The resource pool for the template                                      | required          |
-| folder           | The vm folder to place the template in                                  | required          |
-| datastore        | The datastore to back the template disk                                 | required          |
-| os_type          | The VMWare os type to inject into the OVF (defaults to centos64Guest)   | optional          |
-| os_id            | The VMWare os id to inject into the OVF template (defaults to 107)      | optional          |
-| os_version       | The VMWare os version to inject into the OVF template (defaults to "")  | optional          |
-| vm_name          | The name of the OVF template to upload (defaults to the builder name)   | optional          |
-| hardware_version | The VMWare hardware version to inject into the OVF (defaults to vmx-10) | optional          |
+| Attribute        | Description                                                                            | Required/Optional |
+| ---------------- | -------------------------------------------------------------------------------------- | ----------------- |
+| host             | VCenter host for API calls                                                             | required          |
+| username         | Username to use for auth                                                               | required          |
+| password         | Password to use for auth                                                               | required          |
+| datacenter       | The datacenter where the template will be deployed                                     | required          |
+| datastore        | The datastore to back the template disk                                                | required          |
+| resource_pool    | The resource pool for the template (defaults to the default datacenter resource pool)  | optional          |
+| folder           | The vm folder to place the template in (defaults to the root of the datacenter)        | optional          |
+| os_type          | The VMWare os type to inject into the OVF (defaults to centos64Guest)                  | optional          |
+| os_id            | The VMWare os id to inject into the OVF template (defaults to 107)                     | optional          |
+| os_version       | The VMWare os version to inject into the OVF template (defaults to "")                 | optional          |
+| vm_name          | The name of the OVF template to upload (defaults to the builder name)                  | optional          |
+| hardware_version | The VMWare hardware version to inject into the OVF (defaults to vmx-10)                | optional          |

--- a/plugin.go
+++ b/plugin.go
@@ -13,9 +13,9 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/mitchellh/packer/helper/config"
-	"github.com/mitchellh/packer/packer"
-	"github.com/mitchellh/packer/template/interpolate"
+	"github.com/hashicorp/packer/helper/config"
+	"github.com/hashicorp/packer/packer"
+	"github.com/hashicorp/packer/template/interpolate"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/ovf"

--- a/plugin.go
+++ b/plugin.go
@@ -29,6 +29,7 @@ import (
 var builtins = map[string]string{
 	"mitchellh.virtualbox": "virtualbox",
 	"mitchellh.vmware":     "vmware",
+	"mitchellh.vmware-esx": "vmware",
 }
 
 var virtualboxRe = regexp.MustCompile(`<vssd:VirtualSystemType>virtualbox-(\d)+(\.(\d)+)?<\/vssd:VirtualSystemType>`)


### PR DESCRIPTION
This PR allows the post-processor to be used with the vmware-esx builder, ie when building directly on an esxi host.

It also makes folder and resource_pool optional, and falls back to the root folder and default resource pool if they are not specified.